### PR TITLE
Fixed "Too many clients" bug.

### DIFF
--- a/src/ABulkCopy.APostgres/IPgContext.cs
+++ b/src/ABulkCopy.APostgres/IPgContext.cs
@@ -1,6 +1,6 @@
 ﻿namespace ABulkCopy.APostgres;
 
-public interface IPgContext : IDbContext
+public interface IPgContext : IDbContext, IDisposable
 {
     NpgsqlDataSource DataSource { get; }
 }

--- a/src/ABulkCopy.APostgres/PgContext.cs
+++ b/src/ABulkCopy.APostgres/PgContext.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ABulkCopy.APostgres;
 
@@ -8,9 +9,9 @@ public class PgContext : IPgContext
     private readonly IConfiguration _config;
     private string? _connectionString;
 
-    public PgContext(ILoggerFactory loggerFactory, IConfiguration config)
+    public PgContext(ILoggerFactory? loggerFactory, IConfiguration config)
     {
-        _loggerFactory = loggerFactory;
+        _loggerFactory = loggerFactory ?? new NullLoggerFactory();
         _config = config;
         Rdbms = Rdbms.Pg;
     }
@@ -47,5 +48,11 @@ public class PgContext : IPgContext
             }
             return _dataSource;
         }
+    }
+
+    public void Dispose()
+    {
+        _dataSource?.Dispose();
+        _dataSource = null;
     }
 }

--- a/src/ABulkCopy.Cmd/Config/ServiceCollectionExtensions.cs
+++ b/src/ABulkCopy.Cmd/Config/ServiceCollectionExtensions.cs
@@ -17,7 +17,6 @@ public static class ServiceCollectionExtensions
         this IServiceCollection services)
     {
         services.AddSingleton<PgContext>();
-        services.AddSingleton<IDbContext>(s => s.GetRequiredService<PgContext>());
         services.AddSingleton<IPgContext>(s => s.GetRequiredService<PgContext>());
         services.AddSingleton<IPgCmd, PgCmd>();
         services.AddSingleton<ITypeConverter, PgTypeMapper>();

--- a/src/APostgres.Test/DataReader/PgDataReaderStringTests.cs
+++ b/src/APostgres.Test/DataReader/PgDataReaderStringTests.cs
@@ -138,7 +138,7 @@ public class PgDataReaderStringTests : PgDataReaderTestBase
             new() { col }, 
             new() {testVal});
         var dataReader = new PgDataReader(
-            PgContext,
+            PgDbHelper.Instance.PgContext,
             QBFactoryMock.Object,
             new DataFileReader(FileHelper.FileSystem, TestLogger),
             TestLogger);

--- a/src/APostgres.Test/DataReader/PgDataReaderTestBase.cs
+++ b/src/APostgres.Test/DataReader/PgDataReaderTestBase.cs
@@ -10,7 +10,7 @@ public class PgDataReaderTestBase : PgTestBase
     {
         QBFactoryMock.Setup(f => f.GetQueryBuilder())
             .Returns(() => new QueryBuilder(
-                new Identifier(TestConfiguration, PgContext)));
+                new Identifier(TestConfiguration, PgDbHelper.Instance.PgContext)));
     }
 
     protected async Task<T?> TestDataReader<T>(
@@ -41,7 +41,7 @@ public class PgDataReaderTestBase : PgTestBase
     {
         var tableDefinition = await CreateTableAndDataFile(tableName, cols, fileData);
         var dataReader = new PgDataReader(
-            PgContext,
+            PgDbHelper.Instance.PgContext,
             QBFactoryMock.Object,
             new DataFileReader(FileHelper.FileSystem, TestLogger), 
             TestLogger);

--- a/src/APostgres.Test/PgCmd/PgCmdTests.cs
+++ b/src/APostgres.Test/PgCmd/PgCmdTests.cs
@@ -349,7 +349,7 @@ public class PgCmdTests : PgTestBase
             { Constants.Config.AddQuotes, "true" },
         };
 
-        return new PgSystemTables(PgContext, GetIdentifier(appSettings), TestLogger);
+        return new PgSystemTables(PgDbHelper.Instance.PgContext, GetIdentifier(appSettings), TestLogger);
     }
 
     private IPgCmd GetPgCmd(Dictionary<string, string?>? appSettings=null)
@@ -366,7 +366,7 @@ public class PgCmdTests : PgTestBase
             .Returns(() => new QueryBuilder(
                 GetIdentifier(appSettings)));
         return new ABulkCopy.APostgres.PgCmd(
-            PgContext,
+            PgDbHelper.Instance.PgContext,
             _qbFactoryMock.Object,
             _systemTablesMock.Object,
             TestLogger);

--- a/src/APostgres.Test/PgTestBase.cs
+++ b/src/APostgres.Test/PgTestBase.cs
@@ -5,7 +5,6 @@ public class PgTestBase
     protected readonly ILogger TestLogger;
     protected readonly Microsoft.Extensions.Logging.ILoggerFactory TestLoggerFactory;
     protected readonly IConfiguration TestConfiguration;
-    protected readonly IPgContext PgContext;
 
     protected PgTestBase(ITestOutputHelper output)
     {
@@ -33,8 +32,6 @@ public class PgTestBase
         TestLogger = loggerConfig.CreateLogger();
 
         TestLoggerFactory = new Microsoft.Extensions.Logging.LoggerFactory().AddSerilog(TestLogger);
-
-        PgContext = new PgContext(TestLoggerFactory, TestConfiguration);
     }
 
     //[MethodImpl(MethodImplOptions.NoInlining)]


### PR DESCRIPTION
PgContext was created for every test in PgTestBase. Exposing PgContext from PgDbHelper, and using this PgContext instead. Also added IDisposable to PgContext.