### PR TITLE
Don't prompt when folder doesn't exist

### DIFF
--- a/src/ABulkCopy.Cmd.Internal/CmdArguments.cs
+++ b/src/ABulkCopy.Cmd.Internal/CmdArguments.cs
@@ -23,7 +23,7 @@ public class CmdArguments
     [Option('l', "log-file", Required = false, HelpText = "Full path for log file.")]
     public string? LogFile { get; set; }
 
-    [Option('m', "mappings-file", Required = false, HelpText = "The path and file name of a json file containing key-value pairs for mapping schema names, collation names and some simple type mapping. E.g. mapping the \"dbo\" schema in SQL Server to the \"public\" schema in Postgres. There is a sample-mappings.json file accompanying the executable. For column types, you should only map bit and datetime types (see documentation:  This parameter is only used when direction = In")]
+    [Option('m', "mappings-file", Required = false, HelpText = "The path and file name of a json file containing key-value pairs for mapping schema names, collation names and some simple type mapping. E.g. mapping the \"dbo\" schema in SQL Server to the \"public\" schema in Postgres. There is a sample-mappings.json file accompanying the executable. For column types, you should only map bit and datetime types (see documentation: https://arveh.github.io/ABulkCopy.Docs/command_line_parameters/#-m-mappings-file-in-only). This parameter is only used when direction = In")]
     public string? MappingsFile { get; set; }
 
     [Option("schema-filter", Required = false, HelpText = "A comma separated list of schema names. When it's not used, all schemas will be copied, except 'guest', 'information_schema', 'sys' and 'logs'. This parameter is only used when direction = Out")]

--- a/src/ABulkCopy.Cmd.Internal/DataFolder.cs
+++ b/src/ABulkCopy.Cmd.Internal/DataFolder.cs
@@ -6,17 +6,20 @@ public static class DataFolder
     {
         if (Directory.Exists(folder)) return CmdStatus.Exists;
 
-        Console.Write($"Create '{folder}' [y|n] (n is default)? ");
-        var key = Console.ReadKey();
-        Console.WriteLine();
-        if (key.KeyChar is 'y' or 'Y' or '\n')
+        try
         {
             Directory.CreateDirectory(folder);
             Log.Information("Folder '{Folder}' created", folder);
             Console.WriteLine($"Folder '{folder}' created");
             return CmdStatus.Created;
         }
-
-        return CmdStatus.ShouldExit;
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Folder {Folder} couldn't be created. ABulkCopy.Cmd finished.",
+                folder);
+            Console.WriteLine($"Folder {folder} couldn't be created. {ex.Message} ABulkCopy.Cmd finished.");
+            Console.WriteLine(ex.Message);
+            return CmdStatus.ShouldExit;
+        }
     }
 }

--- a/src/ABulkCopy.Cmd.Internal/DataFolder.cs
+++ b/src/ABulkCopy.Cmd.Internal/DataFolder.cs
@@ -15,9 +15,9 @@ public static class DataFolder
         }
         catch (Exception ex)
         {
-            Log.Error(ex, "Folder {Folder} couldn't be created. ABulkCopy.Cmd finished.",
+            Log.Error(ex, "Folder {Folder} couldn't be created.",
                 folder);
-            Console.WriteLine($"Folder {folder} couldn't be created. {ex.Message} ABulkCopy.Cmd finished.");
+            Console.WriteLine($"Folder {folder} couldn't be created.");
             Console.WriteLine(ex.Message);
             return CmdStatus.ShouldExit;
         }

--- a/src/ABulkCopy.Cmd/Program.cs
+++ b/src/ABulkCopy.Cmd/Program.cs
@@ -39,9 +39,7 @@ public class Program
                 var folder = configuration.Check(Constants.Config.Folder);
                 if (DataFolder.CreateIfNotExists(folder) == CmdStatus.ShouldExit)
                 {
-                    Log.Information("Folder {Folder} didn't exist. ABulkCopy.Cmd finished.",
-                        folder);
-                    Console.WriteLine($"Folder {folder} didn't exist. ABulkCopy.Cmd finished.");
+                    Console.WriteLine("ABulkCopy.Cmd finished.");
                     return;
                 }
 


### PR DESCRIPTION
Decided to not do #40, and remove the prompt for when folder doesn't exist. It doesn't really make sense to prompt here. I'll create a new issue for halting if files are overwritten instead. See #41 